### PR TITLE
bugfix/Notification-onClose-78 - Adicionar propriedade `onClose` ao componente de notificação

### DIFF
--- a/src/components/Notification/index.tsx
+++ b/src/components/Notification/index.tsx
@@ -4,6 +4,7 @@ import { Snackbar, Alert, AlertTitle } from '@mui/material';
 export interface NotificationProps {
   variant: 'error' | 'success';
   message: string;
+  onClose?: Function;
   title?: string;
 }
 
@@ -11,10 +12,14 @@ export const Notification: React.FC<NotificationProps> = ({
   variant,
   message,
   title,
+  onClose,
 }): JSX.Element => {
   const [shouldOpen, setShouldOpen] = useState(true);
 
-  const handleClose = () => setShouldOpen(false);
+  const handleClose = () => {
+    setShouldOpen(false);
+    onClose && onClose();
+  };
 
   const getNotificationTitle = (title: string | undefined) => {
     if (!title) {

--- a/src/components/Notification/notification.test.tsx
+++ b/src/components/Notification/notification.test.tsx
@@ -62,4 +62,23 @@ describe('Componente de notificação', () => {
 
     expect(notificationComponent).not.toBeVisible();
   });
+
+  test('Deve chamar a função passada pela propriedade onClose quando a notificação for fechada', () => {
+    const message = 'Teste de notificação';
+    const onCloseFunction = jest.fn();
+    render(
+      <Notification
+        variant="error"
+        message={message}
+        onClose={onCloseFunction}
+      />,
+    );
+
+    const closeButtonText = 'Fechar';
+    const closeButton = screen.getByTitle(closeButtonText);
+
+    userEvent.click(closeButton);
+
+    expect(onCloseFunction).toBeCalled();
+  });
 });


### PR DESCRIPTION
## Descrição

Sem essa propriedade, é impossível para quem usa o componente chamar várias notificações no mesmo componente

____

**Link do card:**
[Adicionar propriedade `onClose` ao componente de notificação](https://trello.com/c/NOR8Xxr3/78-bug-adicionar-propriedade-onclose-ao-componente-de-notifica%C3%A7%C3%A3o)

____

## Checklist Code Review
Avaliar se todos os itens a seguir foram feitos. Os itens com `*` não são obrigatórios.

- [x] Foi adicionada a descrição da PR
- [x] Foi adicionado o link do card
- [ ] A branch segue o padrão com o prefixo DBI
- [x] Está seguindo os padrões de prefixo do gitflow (feature, bugfix, hotfix, release)
- [x] O título da PR segue o padrão: ***Nome da branch - Título do card***
- [x] A PR está sendo enviada para a branch `develop`
- [x] O Repositório que a PR está sendo enviada é o [**dbinclui-org/dbinclui-frontend**](https://github.com/dbinclui-org/dbinclui-frontend)
- [x] Foi realizado os testes unitários *
- [ ] Foi realizado os testes de E2E *
- [x] Foi adicionada as respectivas **labels**
- [x] A PR foi assinada

Para que haja uma padronização na criação dos componentes, este deve seguir o seguinte modelo de construção:

- [x] Deve ser feita a importação do _React_ no escopo do componente.
- [x] Deve conter uma _interface_ com as propriedades do componente.
- [x] Nome da _interface_ deve ter o sufixo _Props_.
- [x] Recebe _React.FC_, no qual recebe a _interface_
- [x] Deve retornar elemento _JSX_
- [x] O componente de ser exportado ao final como `default`.
 
Exemplo:
```tsx
import React from 'react';

export interface ComponetNameProps {}

export const ComponetName: React.FC<ComponentNameProps> = (): JSX.Element => {
  return <>...</>;
};

export default ComponentName;
```
