### PR TITLE
Feature/DBI-US007-30 - Front - Validar dados

### DIFF
--- a/src/pages/register-category/validator.test.ts
+++ b/src/pages/register-category/validator.test.ts
@@ -1,0 +1,47 @@
+import validateInput from '@pages/register-category/validator';
+
+describe('Função de validação de dados de categoria', () => {
+  test('Deve validar corretamente os dados sem erros', async () => {
+    const data = {
+      title: 'Guia de Acessibilidade',
+      shortDescription: 'Essa é a guia de acessibilidade',
+      guide: 'id-teste',
+    };
+
+    return expect(validateInput(data)).resolves.toEqual(data);
+  });
+
+  test('Deve apontar erro na ausência do título', async () => {
+    const data = {
+      title: '',
+      shortDescription: 'Essa é a guia de acessibilidade',
+      guide: 'id-teste',
+    };
+
+    return expect(validateInput(data)).rejects.toThrow(
+      'O título é obrigatório',
+    );
+  });
+
+  test('Deve apontar erro na ausência da descrição', async () => {
+    const data = {
+      title: 'Guia de Acessibilidade',
+      shortDescription: '',
+      guide: 'id-teste',
+    };
+
+    return expect(validateInput(data)).rejects.toThrow(
+      'A descrição é obrigatória',
+    );
+  });
+
+  test('Deve apontar erro na ausência do guia', async () => {
+    const data = {
+      title: 'Guia de Acessibilidade',
+      shortDescription: 'Essa é a guia de acessibilidade',
+      guide: '',
+    };
+
+    return expect(validateInput(data)).rejects.toThrow('O guia é obrigatório');
+  });
+});

--- a/src/pages/register-category/validator.test.ts
+++ b/src/pages/register-category/validator.test.ts
@@ -19,7 +19,7 @@ describe('Função de validação de dados de categoria', () => {
     };
 
     return expect(validateInput(data)).rejects.toThrow(
-      'O título é obrigatório',
+      'O título da categoria é obrigatório',
     );
   });
 

--- a/src/pages/register-category/validator.ts
+++ b/src/pages/register-category/validator.ts
@@ -10,7 +10,7 @@ export default async function validateInput(
   data: InputInterface,
 ): Promise<InputInterface | yup.ValidationError> {
   const schema = yup.object().shape({
-    title: yup.string().required('O título é obrigatório'),
+    title: yup.string().required('O título da categoria é obrigatório'),
     shortDescription: yup.string().required('A descrição é obrigatória'),
     guide: yup.string().required('O guia é obrigatório'),
   });

--- a/src/pages/register-category/validator.ts
+++ b/src/pages/register-category/validator.ts
@@ -1,0 +1,19 @@
+import * as yup from 'yup';
+
+export interface InputInterface {
+  title: string;
+  shortDescription: string;
+  guide: string;
+}
+
+export default async function validateInput(
+  data: InputInterface,
+): Promise<InputInterface | yup.ValidationError> {
+  const schema = yup.object().shape({
+    title: yup.string().required('O título é obrigatório'),
+    shortDescription: yup.string().required('A descrição é obrigatória'),
+    guide: yup.string().required('O guia é obrigatório'),
+  });
+
+  return await schema.validate(data);
+}


### PR DESCRIPTION
## Descrição

Validação de dados no front-end no registro de categoria. Foi seguido o padrão ditado pelo schema de validação no backend.

____

[US007 - [Front] - Validar dados](https://trello.com/c/K07lgmNz/30-2-us007-front-validar-dados)

____

## Checklist Code Review
Avaliar se todos os itens a seguir foram feitos. Os itens com `*` não são obrigatórios.

- [x] Foi adicionada a descrição da PR
- [x] Foi adicionado o link do card
- [x] A branch segue o padrão com o prefixo DBI
- [x] Está seguindo os padrões de prefixo do gitflow (feature, bugfix, hotfix, release)
- [x] O título da PR segue o padrão: ***Nome da branch - Título do card***
- [x] A PR está sendo enviada para a branch `develop`
- [x] O Repositório que a PR está sendo enviada é o [**dbinclui-org/dbinclui-frontend**](https://github.com/dbinclui-org/dbinclui-frontend)
- [x] Foi realizado os testes unitários *
- [ ] Foi realizado os testes de E2E *
- [x] Foi adicionada as respectivas **labels**
- [x] A PR foi assinada

Para que haja uma padronização na criação dos componentes, este deve seguir o seguinte modelo de construção:

- [ ] Deve ser feita a importação do _React_ no escopo do componente.
- [ ] Deve conter uma _interface_ com as propriedades do componente.
- [ ] Nome da _interface_ deve ter o sufixo _Props_.
- [ ] Recebe _React.FC_, no qual recebe a _interface_
- [ ] Deve retornar elemento _JSX_
- [ ] O componente de ser exportado ao final como `default`.
 
Exemplo:
```tsx
import React from 'react';

export interface ComponetNameProps {}

export const ComponetName: React.FC<ComponentNameProps> = (): JSX.Element => {
  return <>...</>;
};

export default ComponentName;
```